### PR TITLE
Fix ClosedChannelException being raised when releasing lock resources

### DIFF
--- a/src/main/java/com/microsoft/aad/msal4jextensions/CrossProcessCacheFileLock.java
+++ b/src/main/java/com/microsoft/aad/msal4jextensions/CrossProcessCacheFileLock.java
@@ -162,7 +162,7 @@ class CrossProcessCacheFileLock {
 
     private void releaseResources() {
         try {
-            if (lock != null) {
+            if (lock != null && lock.isValid()) {
                 lock.release();
             }
             if (fileChannel != null) {


### PR DESCRIPTION
This PR fixes the problem discussed in issue #26.

The issue with the original code I have found is that subsequent calls of `CrossProcessCacheFileLock#releaseResources` would cause a `java.nio.channels.ClosedChannelException`  to be raised, as the method would attempt to release a lock belonging to a closed channel (the channel was closed after the lock was released, hence why this only occurs on subsequent calls).

A simple fix was given by @npetzall which I have implemented here.